### PR TITLE
Systemd service configuration updates

### DIFF
--- a/foundationdb/configure-and-start-fdb.sh
+++ b/foundationdb/configure-and-start-fdb.sh
@@ -102,7 +102,7 @@ chown -R foundationdb:foundationdb /var/log/foundationdb
 #------------------------------------------------#
 systemctl start foundationdb.service
 systemctl enable foundationdb.service
-systemctl status foundationdb.service
+systemctl --no-pager status foundationdb.service
 
 if [ ! -z "${FDBCLI_COMMAND}" ]; then
   log "Running fdbcli command: \`${FDBCLI_COMMAND}\`"

--- a/postgres/configure-and-start-postgres.sh
+++ b/postgres/configure-and-start-postgres.sh
@@ -100,7 +100,7 @@ fi
 
 systemctl restart postgresql.service
 systemctl enable postgresql.service
-systemctl status postgresql.service
+systemctl --no-pager status postgresql.service
 
 
 trap 'rm -f ~/.pgpass' EXIT

--- a/postgres/install.sh
+++ b/postgres/install.sh
@@ -31,5 +31,5 @@ do
 done
 
 log "Disabling Postgres service for now"
-systemctl disable postgresql.service
-systemctl stop postgresql.service
+systemctl disable postgresql.service || true
+systemctl stop postgresql.service || true


### PR DESCRIPTION
Ensure `systemctl status` does not expect user interaction and allow install `systemctl` commands to fail (e.g. for docker image build)